### PR TITLE
refactor: remove unnecessary f-string

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -1106,7 +1106,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
                 with open(zip_filepath, "rb") as f:
                     dbx.files_upload(f.read(), f"{folder_path}/bw-backup_{timestamp}.zip")
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Dropbox")
-                notification_message = f"ZIP File Uploaded and Encrypted to Dropbox Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Dropbox Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1123,7 +1123,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
                 backup_folder_id = create_folder_if_not_exists(drive_service, "bitwarden-drive-backup", parent_folder_id=env_vars["GOOGLE_FOLDER_ID"])
                 upload_file_to_drive(drive_service, zip_filepath, backup_folder_id)
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Google Drive")
-                notification_message = f"ZIP File Uploaded and Encrypted to Google Drive Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Google Drive Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1139,7 +1139,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
             try:
                 upload_file_to_pcloud(zip_filepath, "bitwarden-drive-backup", secrets["PCLOUD_USERNAME"], secrets["PCLOUD_PASSWORD"])
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to pCloud")
-                notification_message = f"ZIP File Uploaded and Encrypted to pCloud Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to pCloud Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1155,7 +1155,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
             try:
                 upload_file_to_mega(zip_filepath, secrets["MEGA_EMAIL"], secrets["MEGA_PASSWORD"])
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Mega")
-                notification_message = f"ZIP File Uploaded and Encrypted to Mega Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Mega Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1171,7 +1171,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
             try:
                 upload_file_to_nextcloud(zip_filepath, secrets["NEXTCLOUD_URL"], secrets["NEXTCLOUD_USERNAME"], secrets["NEXTCLOUD_PASSWORD"])
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Nextcloud")
-                notification_message = f"ZIP File Uploaded and Encrypted to Nextcloud Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Nextcloud Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1187,7 +1187,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
             try:
                 upload_file_to_seafile(zip_filepath, secrets["SEAFILE_SERVER_URL"], secrets["SEAFILE_USERNAME"], secrets["SEAFILE_PASSWORD"])
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Seafile")
-                notification_message = f"ZIP File Uploaded and Encrypted to Seafile Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Seafile Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1203,7 +1203,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
             try:
                 upload_file_to_filebase(zip_filepath, secrets["FILEBASE_ACCESS_KEY"], secrets["FILEBASE_SECRET_KEY"], f"bw-backup_{timestamp}.zip")
                 logging.info(f"{Fore.GREEN}ZIP file uploaded to Filebase")
-                notification_message = f"ZIP File Uploaded and Encrypted to Filebase Successfully ✅📚🔐☁️"
+                notification_message = "ZIP File Uploaded and Encrypted to Filebase Successfully ✅📚🔐☁️"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1241,7 +1241,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
                     pbar.update(progress_stages[10]["update"])
                 else:
                     logging.error(f"{Fore.RED}Failed to create Todoist task")
-                    notification_message = f"Failed to create Todoist task"
+                    notification_message = "Failed to create Todoist task"
             except Exception as e:
                 logging.error(f"{Fore.RED}Error creating Todoist task: {e}")
                 notification_message = f"Error creating Todoist task: {e}"
@@ -1263,7 +1263,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
                     caldav_username=secrets["CALDAV_USERNAME"],
                     caldav_password=secrets["CALDAV_PASSWORD"]
                 )
-                notification_message = f"CalDAV Event Successfully Created on Bitwarden New Backup Calendar ✅📅"
+                notification_message = "CalDAV Event Successfully Created on Bitwarden New Backup Calendar ✅📅"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])
@@ -1281,7 +1281,7 @@ def backup_bitwarden(env_vars, secrets, drive_service):
                 send_email_with_attachment(env_vars["SMTP_SERVER"], env_vars["SMTP_PORT"], env_vars["SMTP_USERNAME"], env_vars["SMTP_PASSWORD"], env_vars["SENDER_EMAIL"], env_vars["EMAIL_RECIPIENT"], 
                                         "Bitwarden Backup", f"", zip_filepath)
                 logging.info(f"{Fore.GREEN}Email with attachment sent successfully")
-                notification_message = f"ZIP File Sent and Encrypted to Email Successfully ✅📚🔐📧"
+                notification_message = "ZIP File Sent and Encrypted to Email Successfully ✅📚🔐📧"
                 send_telegram_notification(notification_message, env_vars["TELEGRAM_TOKEN"], env_vars["TELEGRAM_CHAT_ID"])
                 send_discord_notification(notification_message, env_vars["DISCORD_WEBHOOK_URL"])
                 send_slack_notification(notification_message, env_vars["SLACK_WEBHOOK_URL"])

--- a/app/import_to_bitwarden.py
+++ b/app/import_to_bitwarden.py
@@ -371,7 +371,7 @@ def restore_items_and_attachments(env_vars, secrets, bw_session, sleep_milliseco
             if result.returncode != 0:
                 logging.error(f"Error during import: {result.stderr}")
                 raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            logging.info(f"Backup imported to Bitwarden successfully")
+            logging.info("Backup imported to Bitwarden successfully")
         except subprocess.CalledProcessError as e:
             logging.error(f"Error during import: {e}. Trying to unlock the vault again.")
             bw_session = unlock_vault(secrets["BW_PASSWORD"])
@@ -380,9 +380,9 @@ def restore_items_and_attachments(env_vars, secrets, bw_session, sleep_milliseco
                 if result.returncode != 0:
                     logging.error(f"Error during import after unlocking the vault: {result.stderr}")
                     raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-                logging.info(f"Backup imported to Bitwarden successfully after unlocking the vault")
+                logging.info("Backup imported to Bitwarden successfully after unlocking the vault")
 
-        logging.info(f"Restoring items finished")
+        logging.info("Restoring items finished")
 
         for _ in tqdm(range(100), desc=f"{Fore.GREEN}Bitwarden JSON Import{Fore.RESET}", ncols=100, bar_format="{l_bar}%s{bar}%s{r_bar}" % (Fore.BLUE, Fore.RESET)):
             time.sleep(0.01)
@@ -392,7 +392,7 @@ def restore_items_and_attachments(env_vars, secrets, bw_session, sleep_milliseco
 
         bitwarden_items = list_bitwarden_items(bw_session)
         if not bitwarden_items:
-            logging.error(f"Failed to retrieve Bitwarden items. Cannot proceed with attachment.")
+            logging.error("Failed to retrieve Bitwarden items. Cannot proceed with attachment.")
             return
 
         attach_files_using_info(attachments_info_file_path, decrypted_attachments_dir_path, bitwarden_items, bw_session, secrets["BW_PASSWORD"])

--- a/app/import_to_keepass.py
+++ b/app/import_to_keepass.py
@@ -405,7 +405,7 @@ def main():
             zf.pwd = ZIP_PASSWORD.encode()
             zf.extractall(temp_dir)
         
-        print(f"Decrypted ZIP contents extracted to temporary directory.")
+        print("Decrypted ZIP contents extracted to temporary directory.")
 
         encrypted_json_file_path = os.path.join(temp_dir, f"bw-backup_{TIMESTAMP}.json")
 


### PR DESCRIPTION
It is wasteful to use `f-string` mechanism if there are no expressions to be extrapolated. It is recommended to use regular strings instead.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>